### PR TITLE
docs: fix docker run cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ IMMICH_MATCH=\.(JPG|RW2)$
 IMMICH_PARENT=\.JPG$
 EOF
 
-docker run -ti --rm --env-file=.env mattdavis90/immich-stacker-latest
+docker run -ti --rm --env-file=.env mattdavis90/immich-stacker
 ```
 
 ### Using Swarm Cronjobs


### PR DESCRIPTION
Just a small fix in the name/tag of the image that is run. `mattdavis90/immich-stacker` automatically gets the latest one, if you want it more verbose, you'd need `mattdavis90/immich-stacker:latest`